### PR TITLE
Use Deployments in Kubernetes

### DIFF
--- a/docker/master/Rprofile_master
+++ b/docker/master/Rprofile_master
@@ -5,5 +5,3 @@ require(doRedis)
 try(registerDoRedis(host='redis', queue='jobs'),silent=T)
 registerDoRedis(host='redis', queue='jobs')
 }
-
-

--- a/kube-setup/redis.yaml
+++ b/kube-setup/redis.yaml
@@ -1,5 +1,5 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: redis-svc
   labels:
@@ -7,11 +7,12 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: redis-svc
+    matchLabels:
+      app: redis-svc
   template:
     metadata:
       labels:
-        name: redis-svc
+        app: redis-svc
     spec:
       containers:
       - name: redis

--- a/kube-setup/redis_service.yaml
+++ b/kube-setup/redis_service.yaml
@@ -6,11 +6,11 @@ metadata:
     name: redis-svc
 spec:
   # Uncomment next line if you want to expose redis to the wilds of the internet -- also useful for accessing this service as a cloud of remote mercenaries from your lappy
-  type: NodePort
+  # type: NodePort
   # get the actual exposed port from  That port will be reported in your Service's spec.ports[*].nodePort field.
   ports:
     # the port that this service should serve on
   - port: 6379
     targetPort: 6379
   selector:
-    name: redis-svc
+    app: redis-svc

--- a/kube-setup/rmaster.yml
+++ b/kube-setup/rmaster.yml
@@ -10,6 +10,6 @@ spec:
     - name: rmaster
       image: "trcook/rdockerhpc_master"
       # command: ["R","--no-save"]
-      command: ["sleep", "1200"]
+      command: ["sleep", "12000"]
 
 

--- a/kube-setup/rworker.yml
+++ b/kube-setup/rworker.yml
@@ -1,5 +1,5 @@
-apiVersion: v1
-kind: ReplicationController
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name: rworker-rc
   labels:
@@ -7,18 +7,13 @@ metadata:
 spec:
   replicas: 1
   selector:
-    name: rworker
-    # sets groups for load balancing
+    matchLabels:
+      app: rworker
   template:
     metadata:
       labels:
-        name: rworker
-        # pods will be named rworker-xxxxx where xxxxx is some random gibberish
+        app: rworker
     spec:
       containers:
       - name: rdockerhpc-worker
         image: trcook/rdockerhpc_worker
-
-
-
-

--- a/readme.md
+++ b/readme.md
@@ -133,7 +133,7 @@ This is not trivial as it potentially lets you set up an army of eager workers i
 To Scale, using kubernetes, we just run: 
 
 ```{bash}
-./kubernetes/cluster/kubectl.sh scale --replicas=3 rc/rworker-rc
+./kubernetes/cluster/kubectl.sh scale --replicas=3 deploy/rworker-rc
 ```
 
 where this will create 3 new workers, running under the rworker-rc. Since the rworker-rc is built to query the redis service, we don't need to worry about setting it up as a service or accessing it externally. Instead, rworker-rc replicas (i.e. pods controlled and provisioned by rworker-rc) will signup with the redis service and have exclusive communication with it. 


### PR DESCRIPTION
Small fix to use `Deployments` instead of `ReplicationControllers` as RCs are being depricated